### PR TITLE
Add interactive Cesium supplier globe demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Supplier Globe</title>
+  <link href="https://unpkg.com/tailwindcss@3.4.10/dist/tailwind.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cesium.com/downloads/cesiumjs/releases/1.110/Build/Cesium/Widgets/widgets.css">
+  <style>
+    html, body, #cesiumContainer {
+      width: 100%;
+      height: 100%;
+      margin: 0;
+      padding: 0;
+      background: #1a1a1a;
+    }
+    .legend {
+      position: absolute;
+      bottom: 1rem;
+      left: 1rem;
+    }
+    .marker-tier2,
+    .marker-tier3 {
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+      margin-right: 0.5rem;
+      border: 2px solid white;
+    }
+    .marker-tier2 { background-color: #10b981; }
+    .marker-tier3 { background-color: #6495ED; }
+    .cesium-infoBox { background: #1a1a1a !important; color: #e5e7eb; }
+    .cesium-infoBox-title { background: #111827 !important; color: #e5e7eb !important; }
+  </style>
+</head>
+<body>
+<div id="cesiumContainer"></div>
+<div class="legend flex text-sm text-gray-300">
+  <div class="flex items-center mr-4">
+    <span class="marker-tier2"></span>Tier 2
+  </div>
+  <div class="flex items-center">
+    <span class="marker-tier3"></span>Tier 3
+  </div>
+</div>
+<script src="https://cesium.com/downloads/cesiumjs/releases/1.110/Build/Cesium/Cesium.js"></script>
+<script>
+Cesium.Ion.defaultAccessToken = 'YOUR_CESIUM_TOKEN_HERE';
+const suppliers = [
+  { name: "Supplier A", lat: 40.7128, lng: -74.0060, tier: "Tier 2", details: "Electronics Components" },
+  { name: "Supplier B", lat: 51.5074, lng: -0.1278, tier: "Tier 2", details: "Automotive Parts" },
+  { name: "Supplier C", lat: 35.6762, lng: 139.6503, tier: "Tier 3", details: "Raw Materials" },
+  { name: "Supplier D", lat: -33.8688, lng: 151.2093, tier: "Tier 3", details: "Packaging Solutions" }
+];
+async function initializeViewer() {
+  let terrainProvider;
+  try {
+    terrainProvider = await Cesium.createWorldTerrainAsync();
+  } catch (err) {
+    console.error('Failed to load world terrain, using ellipsoid terrain.', err);
+    terrainProvider = new Cesium.EllipsoidTerrainProvider();
+  }
+  try {
+    const viewer = new Cesium.Viewer('cesiumContainer', {
+      terrainProvider,
+      imageryProvider: new Cesium.OpenStreetMapImageryProvider({ url: 'https://tile.openstreetmap.org/' }),
+      baseLayerPicker: false,
+      geocoder: false,
+      homeButton: false,
+      scene3DOnly: true,
+      timeline: false,
+      animation: false,
+      navigationHelpButton: false,
+      fullscreenButton: false,
+      infoBox: true
+    });
+    viewer.scene.imageryLayers.get(0).brightness = 0.6;
+    const points = suppliers.map(s => Cesium.Cartesian3.fromDegrees(s.lng, s.lat, 0));
+    suppliers.forEach(s => {
+      const color = s.tier === 'Tier 2' ? Cesium.Color.EMERALD : Cesium.Color.CORNFLOWERBLUE;
+      viewer.entities.add({
+        position: Cesium.Cartesian3.fromDegrees(s.lng, s.lat, 1000),
+        point: { pixelSize: 12, color, outlineColor: Cesium.Color.WHITE, outlineWidth: 2 },
+        description: `<div class='p-2'><div class='font-bold text-gray-100'>${s.name}</div><div>${s.tier}</div><div>${s.details}</div></div>`
+      });
+    });
+    const boundingSphere = Cesium.BoundingSphere.fromPoints(points);
+    viewer.camera.flyToBoundingSphere(boundingSphere, new Cesium.HeadingPitchRange(0, Cesium.Math.toRadians(-45), 30000000));
+  } catch (error) {
+    console.error('Error initializing Cesium viewer:', error);
+    alert('Failed to load the globe. Please check your internet connection or Cesium Ion token.');
+  }
+}
+initializeViewer();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `index.html` with a dark-themed Cesium globe
- show Tier 2 and Tier 3 supplier markers
- include OpenStreetMap imagery and handle terrain loading
- apply Tailwind CSS styling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862e65ce17c8324af1a207a6265ae9d